### PR TITLE
fix parsing negative numbers

### DIFF
--- a/src/OutputParser.elm
+++ b/src/OutputParser.elm
@@ -47,8 +47,8 @@ bool =
 -- NUMBER
 
 
-float : Parser JE.Value
-float =
+num : Parser Float
+num =
     number
         { int = Just toFloat
         , hex = Nothing
@@ -56,6 +56,16 @@ float =
         , binary = Nothing
         , float = Just identity
         }
+
+
+float : Parser JE.Value
+float =
+    oneOf
+        [ succeed negate
+            |. symbol "-"
+            |= num
+        , num
+        ]
         |> map JE.float
 
 

--- a/src/OutputParserTest.elm
+++ b/src/OutputParserTest.elm
@@ -89,9 +89,13 @@ suite =
                         Expect.pass
 
                     Err err ->
-                        let
-                            _ =
-                                Debug.log "err" err
-                        in
+                        Expect.fail "Couldn't parse"
+        , test "works with negative numbers" <|
+            \() ->
+                case parse "(SomeThingWithANumber -1, {})" of
+                    Ok _ ->
+                        Expect.pass
+
+                    Err err ->
                         Expect.fail "Couldn't parse"
         ]


### PR DESCRIPTION
The parser would choke on negative numbers before.
This fix applies the solution suggested [here](https://package.elm-lang.org/packages/elm/parser/latest/Parser#int)

Closes #5 